### PR TITLE
Workaround fix for navigation of quick links demo app

### DIFF
--- a/Demo-Apps/quick_links_app/app/scripts/app.js
+++ b/Demo-Apps/quick_links_app/app/scripts/app.js
@@ -59,7 +59,7 @@ $(document).ready(function() {
   //Displays the updated the list in the UI
   function displayBookmarks() {
     $('.bookmarks-ul').html('');
-    var template = '<li class="bookmarks-li"><a href="https://${domainName}/a/tickets/${id}" target="_top" class="bookmark-link">${subject}</a></li>';
+    var template = '<li class="bookmarks-li"><a href="https://${domainName}/a/tickets/${id}" target="_blank" class="bookmark-link">${subject}</a></li>';
     tickets.forEach(function(val){
       val.domainName = domainName;
       $.tmpl( template, val).appendTo('.bookmarks-ul');


### PR DESCRIPTION
Currently, the quick links demo app throws `Unsafe JavaScript attempt to initiate navigation for frame with origin` when the quick links are clicked.

![image](https://user-images.githubusercontent.com/54354090/95195717-977e8d00-07f4-11eb-8fa5-6451c0842765.png)

As a workaround fix, we can open the quick links in the new tab(which also maintains the tab which agent is viewing currently)