### PR TITLE
Load npm needle

### DIFF
--- a/Demo-Apps/ticket_merger/server/helpers.js
+++ b/Demo-Apps/ticket_merger/server/helpers.js
@@ -1,4 +1,4 @@
-var needle = loadDependency('needle');
+var needle = require('needle');
 
 needle.defaults({
   json: true,

--- a/Demo-Apps/ticket_merger/server/helpers.js
+++ b/Demo-Apps/ticket_merger/server/helpers.js
@@ -1,4 +1,4 @@
-var needle = require('needle');
+var needle = require('needle');   
 
 needle.defaults({
   json: true,


### PR DESCRIPTION
Changing the function from loadDependency("needle") to require("needle") fixes the following error

var needle = (cov_21fw1getpg.s[0]++, loadDependency('needle'));
^

ReferenceError: loadDependency is not defined