### PR TITLE
📦 NEW: configuration features - apps

### DIFF
--- a/Freshworks-Samples/App-Development-Features/Configuration-Features/config-iparams-html-freshdesk/manifest.json
+++ b/Freshworks-Samples/App-Development-Features/Configuration-Features/config-iparams-html-freshdesk/manifest.json
@@ -9,5 +9,6 @@
         }
       }
     }
-  }
+  },
+  "whitelisted-domains": ["https://official-joke-api.appspot.com"]
 }

--- a/Freshworks-Samples/App-Development-Features/Configuration-Features/config-iparams-html-freshservice/manifest.json
+++ b/Freshworks-Samples/App-Development-Features/Configuration-Features/config-iparams-html-freshservice/manifest.json
@@ -9,5 +9,6 @@
         }
       }
     }
-  }
+  },
+  "whitelisted-domains": ["https://official-joke-api.appspot.com"]
 }

--- a/Freshworks-Samples/App-Development-Features/Configuration-Features/config-iparams-json-freshdesk/manifest.json
+++ b/Freshworks-Samples/App-Development-Features/Configuration-Features/config-iparams-json-freshdesk/manifest.json
@@ -9,5 +9,6 @@
         }
       }
     }
-  }
+  },
+  "whitelisted-domains": ["https://<%= iparam.creatorDomain %>.freshdesk.com"]
 }

--- a/Freshworks-Samples/App-Development-Features/Configuration-Features/config-iparams-json-freshservice/manifest.json
+++ b/Freshworks-Samples/App-Development-Features/Configuration-Features/config-iparams-json-freshservice/manifest.json
@@ -1,5 +1,5 @@
 {
-  "platform-version": "2.1",
+  "platform-version": "2.0",
   "product": {
     "freshservice": {
       "location": {
@@ -9,5 +9,6 @@
         }
       }
     }
-  }
+  },
+  "whitelisted-domains": ["https://<%= iparam.creatorDomain %>.freshservice.com"]
 }

--- a/Freshworks-Samples/App-Development-Features/Configuration-Features/config-placeholders-freshdesk/manifest.json
+++ b/Freshworks-Samples/App-Development-Features/Configuration-Features/config-placeholders-freshdesk/manifest.json
@@ -72,5 +72,6 @@
         }
       }
     }
-  }
+  },
+  "whitelisted-domains": ["https://official-joke-api.appspot.com"]
 }

--- a/Freshworks-Samples/App-Development-Features/Configuration-Features/config-placeholders-freshservice/manifest.json
+++ b/Freshworks-Samples/App-Development-Features/Configuration-Features/config-placeholders-freshservice/manifest.json
@@ -1,5 +1,5 @@
 {
-  "platform-version": "2.1",
+  "platform-version": "2.0",
   "product": {
     "freshservice": {
       "location": {
@@ -14,7 +14,7 @@
           "icon": "styles/images/helicopter.svg"
         },
 
-        "ticket_requester_info": { 
+        "ticket_requester_info": {
           "url": "views/ticket_details_page/ticket_requester_info.html",
           "icon": "styles/images/aeroplane.svg"
         },
@@ -23,7 +23,7 @@
           "url": "views/ticket_details_page/ticket_top_navigation.html",
           "icon": "styles/images/aeroplane.svg"
         },
-        
+
         "ticket_background": {
           "url": "views/ticket_details_page/ticket_background.html"
         },


### PR DESCRIPTION
1. Based on recent security updates, updated few apps with whitelisting domains attribute.
2. Reverted some apps back to the 2.0 platform version. Currently, the engineering team expects 2.1 alone for Omni apps.